### PR TITLE
Add encoder noise filtering and closed-loop deadband

### DIFF
--- a/ESP32-GCodeInterpreter.ino
+++ b/ESP32-GCodeInterpreter.ino
@@ -30,11 +30,13 @@ int encoderPinsA[6] = { 22, -1, -1, -1, -1, -1 };
 int encoderPinsB[6] = { 23, -1, -1, -1, -1, -1 };
 int encoderPPR[6] = { 200, 0, 0, 0, 0, 0 };
 int encoderLastState[6] = { 0, 0, 0, 0, 0, 0 };
+int encoderDeltaAccumulator[6] = { 0, 0, 0, 0, 0, 0 };
 // Ratio of motor steps to each encoder count for closed-loop correction (0 = auto-calibrate)
 float motorStepsPerEncoderCount[6] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
 bool closedLoopAxis[6] = { true, false, false, false, false, false };
 
 const long closedLoopToleranceSteps = 20;
+const long closedLoopDeadbandSteps = 3;
 
 ///End Stepper Motors///
 
@@ -340,13 +342,23 @@ void serviceEncoders() {
     }
 
     if (delta != 0) {
-      motors[i].encoderCount += delta;
-      if (encoderPPR[i] > 0) {
-        motors[i].encoderPosition = (double)motors[i].encoderCount / (double)encoderPPR[i];
+      int accumulated = encoderDeltaAccumulator[i];
+      if (accumulated == 0 || (accumulated > 0 && delta > 0) || (accumulated < 0 && delta < 0)) {
+        encoderDeltaAccumulator[i] += delta;
       } else {
-        motors[i].encoderPosition = (double)motors[i].encoderCount;
+        encoderDeltaAccumulator[i] = delta;
       }
-      WriteLine(motors[i].encoderPosition);
+
+      if (std::abs(encoderDeltaAccumulator[i]) >= 2) {
+        motors[i].encoderCount += encoderDeltaAccumulator[i];
+        encoderDeltaAccumulator[i] = 0;
+        if (encoderPPR[i] > 0) {
+          motors[i].encoderPosition = (double)motors[i].encoderCount / (double)encoderPPR[i];
+        } else {
+          motors[i].encoderPosition = (double)motors[i].encoderCount;
+        }
+        WriteLine(motors[i].encoderPosition);
+      }
     }
 
     encoderLastState[i] = state;
@@ -387,6 +399,14 @@ void maintainClosedLoopAxes() {
     long desired = motors[i].targetPos;
     long error = desired - estimatedRounded;
     long absError = error >= 0 ? error : -error;
+
+    if (absError < closedLoopDeadbandSteps) {
+      error = 0;
+      absError = 0;
+      motors[i].targetPos = estimatedRounded;
+      syncEncoderReference(i);
+    }
+
     if (absError >= closedLoopToleranceSteps) {
       int correctionSpeed = speeds[i] > 0 ? speeds[i] : 1;
       startMoveTo(i, desired, correctionSpeed);
@@ -424,6 +444,12 @@ void serviceMotors() {
         motors[i].encoderCountsPerStep = (double)encoderDelta / (double)stepDelta;
       }
       if (!motors[i].homing) {
+        double estimatedSteps = 0.0;
+        if (encoderStepsEstimate(i, estimatedSteps)) {
+          long rounded = (long)std::lround(estimatedSteps);
+          motors[i].currentPos = rounded;
+          motors[i].targetPos = rounded;
+        }
         syncEncoderReference(i);
       }
       if (motors[i].homing) {


### PR DESCRIPTION
## Summary
- debounce encoder transitions by accumulating consistent steps before applying counts
- add a closed-loop deadband to ignore tiny position errors and resync targets when idle
- align target positions to encoder feedback after moves to avoid correcting post-move noise

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7290a7b88326b86c6929817c63c8)